### PR TITLE
Moving to py3 and changing the tikz env specification in the md file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:9-slim
+FROM debian:bullseye-slim
 RUN apt -y update
 RUN apt -y install --no-install-recommends texlive-base pandoc latexmk
 RUN apt -y install --no-install-recommends texlive-latex-extra texlive-fonts-extra texlive-fonts-recommended lmodern
-RUN apt -y install --no-install-recommends python-pip python-setuptools && pip install bdist-venv pandocfilters
+RUN apt -y install --no-install-recommends python3-pip python3-setuptools && pip install bdist-venv pandocfilters
 RUN apt -y install --no-install-recommends imagemagick
 RUN apt -y install --no-install-recommends ghostscript

--- a/example.md
+++ b/example.md
@@ -1,7 +1,8 @@
 Use this
 
 
-```latex
+~~~{.latex}
+```{.tikz}
 \begin{tikzpicture}
 
 \def \n {5}
@@ -15,11 +16,12 @@ Use this
     arc ({360/\n * (\s - 1)+\margin}:{360/\n * (\s)-\margin}:\radius);
 }
 \end{tikzpicture}
-
 ```
+~~~
 
 to get 
 
+```{.tikz}
 \begin{tikzpicture}
 
 \def \n {5}
@@ -33,5 +35,5 @@ to get
     arc ({360/\n * (\s - 1)+\margin}:{360/\n * (\s)-\margin}:\radius);
 }
 \end{tikzpicture}
-
+```
 

--- a/tikz.py
+++ b/tikz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Pandoc filter to process raw latex tikz environments into images.
@@ -14,6 +14,7 @@ import sys
 from subprocess import call
 from tempfile import mkdtemp
 
+import pandocfilters
 from pandocfilters import toJSONFilter, Para, Image, get_filename4code, get_extension
 
 lg = open('log.txt', 'w+')
@@ -22,6 +23,7 @@ def tikz2image(tikz_src, filetype, outfile):
     tmpdir = mkdtemp()
     olddir = os.getcwd()
     os.chdir(tmpdir)
+
     f = open('tikz.tex', 'w')
     f.write("""\\documentclass{standalone}
              \\usepackage{tikz}
@@ -36,7 +38,7 @@ def tikz2image(tikz_src, filetype, outfile):
     lg.write('files={}\n'.format(os.listdir(tmpdir)))
     os.chdir(olddir)
     lg.write("olddir='{}', tmpdir='{}'\n".format(olddir, tmpdir))
-    lg.write("filetype='{}', file='{}'\n".format(filetype, file))
+    lg.write("filetype='{}', file='{}'\n".format(filetype, 'tikz.tex'))
     if filetype == 'pdf':
         f1 = os.path.join(tmpdir, 'tikz.pdf')
         f2 = '{}.pdf'.format(outfile)
@@ -52,9 +54,9 @@ def tikz2image(tikz_src, filetype, outfile):
 
 
 def tikz(key, value, format, _):
-    if key == 'RawBlock':
+    if key == 'CodeBlock':
         [fmt, code] = value
-        if fmt == "latex" and re.match("\\\\begin{tikzpicture}", code):
+        if "tikz" in fmt[1]:
             outfile = get_filename4code("tikz", code)
             filetype = get_extension(format, "png", html="png", latex="pdf")
             src = outfile + '.' + filetype


### PR DESCRIPTION
Hi, 

I suggest the following modifications which move to python3 and also change the way the tikz figure gets recognized and parsed. 

Actually I followed the same convention as [pandoc-filter-graphviz](https://github.com/Hakuyume/pandoc-filter-graphviz) of placing the figure within backquotes :

```{.tikz}
....
```

rather than raw_tex. 

That might be a weird modification, you choose. Actually I did this because I didn't know why the regexp matching was not detecting the \begin{tikzpicture}   in another project using pandoc where I used a collection of pandoc options  "pandoc -r markdown+emoji+tex_math_dollars+simple_tables+table_captions+yaml_metadata_block+fenced_code_attributes .." . So the change in tikz figure declaration is not a bug (your dockerfile runs perfectly well) but a modification I had to do to allow your filter to work with other pandoc options.

